### PR TITLE
Fix Redis connection & repository helper bugs

### DIFF
--- a/src/api/dependencies.py
+++ b/src/api/dependencies.py
@@ -35,12 +35,13 @@ async def get_current_user_id(token: str = Depends(get_token)) -> int:
 UserIdDep = Annotated[int, Depends(get_current_user_id)]
 
 
-async def is_permitted(request: Request, role: str) -> bool:
-    user_id = await get_current_user_id()
+async def is_permitted(request: Request, role: str, user_id: UserIdDep) -> bool:
+    # Use the resolved current user id instead of calling the dependency
+    # function manually so that token extraction works correctly.
     user_role = await AuthService().get_user_role(user_id)
     if user_role != role:
         raise PermissionError(f"User does not have the required role: {role}")
     return True
 
 
-RoleDep = Annotated[str, Depends(is_permitted)]
+RoleDep = Annotated[bool, Depends(is_permitted)]

--- a/src/connectors/redis_connector.py
+++ b/src/connectors/redis_connector.py
@@ -11,9 +11,15 @@ class RedisManager:
         self.port = port
 
     async def connect(self):
-        logging.info(f"Начинаю подключение к Redis host={self.host}, port={self.port}")
-        self._redis = await redis.Redis(host=self.host, port=self.port)
-        logging.info(f"Успешное подключение к Redis host={self.host}, port={self.port}")
+        logging.info(
+            f"Начинаю подключение к Redis host={self.host}, port={self.port}"
+        )
+        # redis.asyncio.Redis constructor is synchronous, awaiting it causes
+        # a TypeError.  We simply instantiate the client here.
+        self._redis = redis.Redis(host=self.host, port=self.port)
+        logging.info(
+            f"Успешное подключение к Redis host={self.host}, port={self.port}"
+        )
 
     async def set(self, key: str, value: str, expire: int | None = None):
         logging.info(f"Установка значения по ключу: {key}")

--- a/src/repositories/base.py
+++ b/src/repositories/base.py
@@ -54,8 +54,7 @@ class BaseRepository:
         или None, если ничего не найдено.
         """
         document = await self.collection.find_one(filter_by)
-
-        self.mapper.map_to_domain_entity(document)
+        return self.mapper.map_to_domain_entity(document)
 
     async def get_one(self, **filter_by: Any) -> Any:
         """
@@ -95,7 +94,7 @@ class BaseRepository:
         try:
             result = await self.collection.insert_many(docs, ordered=False)
         except BulkWriteError:
-            ObjectAlreadyExistsException
+            raise ObjectAlreadyExistsException
 
         # получаем вставленные документы по их _id (чтобы получить все поля, включая _id)
         inserted_ids = result.inserted_ids


### PR DESCRIPTION
## Summary
- fix `RedisManager.connect` awaiting a constructor
- return value from `BaseRepository.get_one_or_none`
- raise on duplicate insert in `BaseRepository.add_batch`
- use dependency injection in `is_permitted`

## Testing
- `python -m compileall -q src`

------
https://chatgpt.com/codex/tasks/task_e_68808d724b1c8330aeed0f6d4eae9a2e